### PR TITLE
tenancy for Laravelでテナント毎に別スキーマ（別DB）に分割されるように修正でテナント毎に別スキーマ（別DB）に分割されるように修正 (vibe-kanban)

### DIFF
--- a/backend/app/Providers/TenancyServiceProvider.php
+++ b/backend/app/Providers/TenancyServiceProvider.php
@@ -27,7 +27,7 @@ class TenancyServiceProvider extends ServiceProvider
                 JobPipeline::make([
                     Jobs\CreateDatabase::class,
                     Jobs\MigrateDatabase::class,
-                    // Jobs\SeedDatabase::class,
+                    Jobs\SeedDatabase::class,
 
                     // Your own jobs to prepare the tenant.
                     // Provision API keys, create S3 buckets, anything you want!

--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('DB_CONNECTION', 'mysql'),
+    'default' => env('DB_CONNECTION', 'central'),
 
     /*
     |--------------------------------------------------------------------------
@@ -72,6 +72,27 @@ return [
             'port' => env('DB_PORT', '3306'),
             'database' => null, // テナントデータベース名は動的に生成される
             'username' => env('DB_USERNAME', 'root'), // テナントデータベース用のDBユーザーは動的に生成される
+            'password' => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'strict' => true,
+            'engine' => null,
+            'options' => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],
+
+        // テンプレート接続（tenancyが動的に `tenant` 接続を生成するために使用）
+        'tenant_template' => [
+            'driver' => 'mysql',
+            'url' => env('DATABASE_URL'),
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '3306'),
+            'database' => null,
+            'username' => env('DB_USERNAME', 'root'),
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',

--- a/backend/config/tenancy.php
+++ b/backend/config/tenancy.php
@@ -39,7 +39,7 @@ return [
      * データベーステナンシー設定。DatabaseTenancyBootstrapperで使用されます。
      */
     'database' => [
-        'central_connection' => env('DB_CONNECTION', 'central'),
+        'central_connection' => 'central',
 
         /**
          * 動的に作成されるテナントデータベース接続の「テンプレート」として使用される接続
@@ -191,7 +191,7 @@ return [
      * tenants:seedコマンドで使用されるパラメータ
      */
     'seeder_parameters' => [
-        '--class' => 'DatabaseSeeder', // ルートシーダークラス
+        '--class' => 'TenantSeeder', // テナントDB用シーダークラス
         // '--force' => true, // 本番環境でテナントデータベースをシードするには、これをtrueにする必要があります
     ],
 ];

--- a/backend/database/migrations/2019_09_15_000010_create_tenants_table.php
+++ b/backend/database/migrations/2019_09_15_000010_create_tenants_table.php
@@ -33,3 +33,4 @@ class CreateTenantsTable extends Migration
         Schema::dropIfExists('tenants');
     }
 }
+

--- a/backend/database/migrations/2019_09_15_000020_create_domains_table.php
+++ b/backend/database/migrations/2019_09_15_000020_create_domains_table.php
@@ -35,3 +35,4 @@ class CreateDomainsTable extends Migration
         Schema::dropIfExists('domains');
     }
 }
+

--- a/backend/database/migrations/tenant/2014_10_12_000000_create_users_table.php
+++ b/backend/database/migrations/tenant/2014_10_12_000000_create_users_table.php
@@ -30,3 +30,4 @@ return new class extends Migration
         Schema::dropIfExists('users');
     }
 };
+

--- a/backend/database/migrations/tenant/2014_10_12_100000_create_password_reset_tokens_table.php
+++ b/backend/database/migrations/tenant/2014_10_12_100000_create_password_reset_tokens_table.php
@@ -26,3 +26,4 @@ return new class extends Migration
         Schema::dropIfExists('password_reset_tokens');
     }
 };
+

--- a/backend/database/migrations/tenant/2019_08_19_000000_create_failed_jobs_table.php
+++ b/backend/database/migrations/tenant/2019_08_19_000000_create_failed_jobs_table.php
@@ -30,3 +30,4 @@ return new class extends Migration
         Schema::dropIfExists('failed_jobs');
     }
 };
+

--- a/backend/database/migrations/tenant/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/backend/database/migrations/tenant/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -34,3 +34,4 @@ return new class extends Migration
         Schema::dropIfExists('personal_access_tokens');
     }
 };
+

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -12,8 +12,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call([
-            DemoUserSeeder::class,
-        ]);
+        // セントラルDB用の初期データがあればここで呼び出してください。
     }
 }


### PR DESCRIPTION
現在tenancy for Laravelを導入していますが一つのDBにすべてのテナントが入るようになっています。マルチDB方式にして、テナント情報はセントラルDBにテナント情報は各テナントごとのテナントDBに格納されるように修正してください！
必要に応じて以下の公式ドキュメントを参考にしてください
https://tenancyforlaravel.com/docs/v3/introduction/
